### PR TITLE
Mixed improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,32 @@
 
 ![screeshot](http://i.imgur.com/2uqR3Tg.png)
 
-It’s  alpha-ish, but works. 
-Please contribute and/or file bugs. 
+It’s beta, but works.
+Please contribute and/or file bugs.
 
 ## Customization
-In its preconfigured form it completes words (searches the document for words, suggests existing words if you type them again). This add-on will require configuration if you want it to autocomplete anything else. 
+In its preconfigured form it completes words (searches the document for words, suggests existing words if you type them again). This add-on will require configuration if you want it to autocomplete anything else.
+
+### Pre-configured flags
+
+* `processKeyEvent`: define if ep_autocomp should handle ace key events (arrow keys, ENTER, etc). Default: true
+* `processEditEvent`: define if ep_autocomp should handle ace edit events (user editing a word). Default: true
+* `showOnEmptyWords`: define if suggestions should be displayed even when user didn't type any word. Useful for plugins that control when suggestions are displayed or not. Default: false
+* `caseSensitiveMatch`: define if suggestions should respect case of typed words. Default: true
+* `ignoreLatinCharacters`: define if Latin characters should be considered the same as their non-Latin equivalents. Ex: user types "a", suggestions include words like "ál", "ão", etc. Default: false
+
+
+### Advanced customization
 
 See the value `autocomp.config` in the  `ep_autocomp/static/js/autocomp.js` file
 for customizing simple cases and the value `autocomp.getPossibleSuggestions` for more complex customizations.
 
-Originally, this was written to autocomplete hashtags, you may want to complet from list of predefined keywords or from a hash of usernames after typing an *@* etc. There are some examples in the sourcecode. 
+Originally, this was written to autocomplete hashtags, you may want to complet from list of predefined keywords or from a hash of usernames after typing an *@* etc. There are some examples in the sourcecode.
 
 ## Install
 Open terminal, navigate  to your etherpad folder and: type `npm install ep_autocomp` OR type `git clone https://github.com/jdittrich/ep_autocomp.git node_modules/ep_autocomp`
 
-# Autocompletion 
+# Autocompletion
 
 Enable under settings
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "0.0.2",
   "description": "autocompletion",
   "author": "Jan Dittrich, <d_jan@ymail.com>",
+  "contributors": [
+    {
+      "name": "Luiza Pagliari",
+      "email": "lpagliari@gmail.com"
+    },
+    {
+      "name": "Joas Souza",
+      "email": "joassouzasantos@gmail.com"
+    }
+  ],
   "engines": {
     "node": ">= 0.6.0"
   },

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -136,7 +136,7 @@ var autocomp = {
 		//if key is ENTER, read out the complementation, close autocomplete menu and input it at cursor. It will reopen tough, if there is still something to complete. No problem, on a " " or any other non completable character and it is gone again.
 		if($autocomp.is(":visible")){
 			//ENTER PRESSED
-			if(context.evt.keyCode === 13){
+			if(this.enterPressed(context.evt)){
         var textReplaced = this.selectSuggestion(context);
         if (textReplaced) {
 					context.evt.preventDefault();
@@ -147,14 +147,13 @@ var autocomp = {
 			}
 
 			//UP PRESSED
-			if(context.evt.keyCode === 38){
+			if(this.upPressed(context.evt)){
 				this.moveSelectionUp();
 				context.evt.preventDefault();
 				return true;
-
 			}
 			//DOWN PRESSED
-			if(context.evt.keyCode === 40){
+			if(this.downPressed(context.evt)){
         this.moveSelectionDown();
 				context.evt.preventDefault();
 				return true;
@@ -170,7 +169,7 @@ var autocomp = {
 		}
 
 		//SPACE AND CONTROL PRESSED
-		if(context.evt.keyCode === 32 && context.evt.ctrlKey){
+		if(this.ctrlSpacePressed(context.evt)){
 			if($autocomp.is(":hidden")){
         autocomp.update(context);
         $autocomp.show();
@@ -181,6 +180,20 @@ var autocomp = {
 			return true;
 		}
 	},
+  enterPressed: function(evt) {
+    return evt.keyCode === 13;
+  },
+  upPressed: function(evt) {
+    // check for shift to avoid confusing "↑" with "&" (shift+7)
+    return !evt.shiftKey && evt.keyCode === 38;
+  },
+  downPressed: function(evt) {
+    // check for shift to avoid confusing "↓" with "(" (shift+9)
+    return !evt.shiftKey && evt.keyCode === 40;
+  },
+  ctrlSpacePressed: function(evt) {
+    return evt.ctrlKey && evt.keyCode === 32;
+  },
   moveSelectionDown:function(){
     //only do it if the selection is not on the last element already
     if(!($list.children().last().hasClass("selected"))){

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -29,6 +29,9 @@ var autocomp = {
   showOnEmptyWords: false,
   // flag to allow show suggestions with/without case sensitive
   caseSensitiveMatch: true,
+  // flag to consider Latin characters as their non-Latin equivalents
+  // (user types "a" and we show suggestions like "ál", "ão", etc.)
+  ignoreLatinCharacters: false,
 
   // collection of callbacks to be called after user selects a suggestion from the list
   postSuggestionSelectedCallbacks: [],
@@ -310,19 +313,51 @@ var autocomp = {
 		return filteredSuggestions;
 	},
 
-  subtextOfSuggestion:function(possibleSuggestion, partialWord){
-    var isSubText;
-    // check if it should be considered matches without matching case
-    if (this.caseSensitiveMatch){
-      isSubText = (possibleSuggestion.indexOf(partialWord) === 0);
-    }else{
-      //turn possibleSuggestion and partialWord to lower case
-      var suggestionLowerCase = possibleSuggestion.toLowerCase();
-      var partialWordLowerCase = partialWord.toLowerCase();
-      //compares words without case
-      isSubText = (suggestionLowerCase.indexOf(partialWordLowerCase) === 0);
+  subtextOfSuggestion: function(possibleSuggestion, partialWord){
+    var transformedPossibleSuggestion = possibleSuggestion;
+    var transformedPartialWord        = partialWord;
+
+    // check if it should ignore Latin characters
+    if (this.ignoreLatinCharacters) {
+      transformedPossibleSuggestion = this.replaceLatinCharacters(transformedPossibleSuggestion);
     }
+
+    // check if it should be considered matches without matching case
+    if (!this.caseSensitiveMatch) {
+      transformedPossibleSuggestion = transformedPossibleSuggestion.toLowerCase();
+      transformedPartialWord        = transformedPartialWord.toLowerCase();
+    }
+
+    // compare words
+    var isSubText = (transformedPossibleSuggestion.indexOf(transformedPartialWord) === 0);
+
     return isSubText;
+  },
+
+  /*
+     Replace Latin characters with non-Latin equivalents.
+     Currently replaces (both uppercase and lowercase):
+       á, à, ä, ã, â,
+       é, è, ë, ê,
+       í, ì, ï, î,
+       ó, ò, ö, õ, ô,
+       ú, ù, ü, û,
+       ç
+   */
+  replaceLatinCharacters: function(originalText) {
+    return originalText.
+      replace(/[àáäãâ]/g, "a").
+      replace(/[ÀÁÄÃÂ]/g, "A").
+      replace(/[èéëê]/g, "e").
+      replace(/[ÈÉËÊ]/g, "E").
+      replace(/[ìíïî]/g, "i").
+      replace(/[ÌÍÏÎ]/g, "I").
+      replace(/[òóöõô]/g, "o").
+      replace(/[ÒÓÖÕÔ]/g, "O").
+      replace(/[ùúüû]/g, "u").
+      replace(/[ÙÚÜÛ]/g, "U").
+      replace(/[ç]/g, "c").
+      replace(/[Ç]/g, "C");
   },
 
 	cursorPosition:function(context){

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -244,13 +244,28 @@ var autocomp = {
           $(currentElement).off("sendkeys");
         });
       });
-
-      $(currentElement).sendkeys(textToInsert);
+      // Empty lines always have a <br>, so due to problems with inserting text
+      // with sendkeys, in this case, we need to insert the html directly
+      var emptyLine = $(currentElement).find("br");
+      var isEmpty = emptyLine.length;
+      if (isEmpty){
+        emptyLine.replaceWith("<span>" + textToInsert + "</span>");
+        this.adjustCaretPosition(currentElement, textToInsert);
+      }else{
+        $(currentElement).sendkeys(textToInsert);
+      }
       $autocomp.hide();
       autocomp.tempDisabledHelper();
       suggestionFound = true;
     }
     return suggestionFound;
+  },
+  adjustCaretPosition:function(currentElement, textToInsert){
+    var rightarrows = "";
+    for (var i = textToInsert.length - 1; i >= 0; i--) {
+      rightarrows += '{rightarrow}';
+    };
+    $(currentElement).sendkeys(rightarrows);
   },
   closeSuggestionBox:function(){
     autocomp.tempDisabledHelper();

--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -251,6 +251,178 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
   });
 
+  context("when flag to show suggestions for Latin characters is turned on", function(){
+
+    // enable flag to consider Latin chars as regular chars
+    beforeEach(function(){
+      var autocomp = helper.padChrome$.window.autocomp;
+      autocomp.ignoreLatinCharacters = true;
+      // ignore case just to make tests easier -- so we don't need to create the double
+      // of test scenarios
+      autocomp.caseSensitiveMatch = false;
+    });
+
+    it("shows suggestions for 'á', 'à', 'ä', 'ã', 'â', 'Á', 'À', 'Ä', 'Ã', 'Â'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dá dà dä dã dâ dÁ dÀ dÄ dÃ dÂ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('da');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dá");
+        expect(suggestions).to.contain("dà");
+        expect(suggestions).to.contain("dä");
+        expect(suggestions).to.contain("dã");
+        expect(suggestions).to.contain("dâ");
+        expect(suggestions).to.contain("dÁ");
+        expect(suggestions).to.contain("dÀ");
+        expect(suggestions).to.contain("dÄ");
+        expect(suggestions).to.contain("dÃ");
+        expect(suggestions).to.contain("dÂ");
+        done();
+      });
+    });
+
+    it("shows suggestions for 'é', 'è', 'ë', 'ê', 'É', 'È', 'Ë', 'Ê'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dé dè dë dê dÉ dÈ dË dÊ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('de');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dé");
+        expect(suggestions).to.contain("dè");
+        expect(suggestions).to.contain("dë");
+        expect(suggestions).to.contain("dê");
+        expect(suggestions).to.contain("dÉ");
+        expect(suggestions).to.contain("dÈ");
+        expect(suggestions).to.contain("dË");
+        expect(suggestions).to.contain("dÊ");
+        done();
+      });
+    });
+
+    it("shows suggestions for 'í', 'ì', 'ï', 'î', 'Í', 'Ì', 'Ï', 'Î'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dí dì dï dî dÍ dÌ dÏ dÎ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('di');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dí");
+        expect(suggestions).to.contain("dì");
+        expect(suggestions).to.contain("dï");
+        expect(suggestions).to.contain("dî");
+        expect(suggestions).to.contain("dÍ");
+        expect(suggestions).to.contain("dÌ");
+        expect(suggestions).to.contain("dÏ");
+        expect(suggestions).to.contain("dÎ");
+        done();
+      });
+    });
+
+    it("shows suggestions for 'ó', 'ò', 'ö', 'õ', 'ô', 'Ó', 'Ò', 'Ö', 'Õ', 'Ô'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dó dò dö dõ dô dÓ dÒ dÖ dÕ dÔ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('do');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dó");
+        expect(suggestions).to.contain("dò");
+        expect(suggestions).to.contain("dö");
+        expect(suggestions).to.contain("dõ");
+        expect(suggestions).to.contain("dô");
+        expect(suggestions).to.contain("dÓ");
+        expect(suggestions).to.contain("dÒ");
+        expect(suggestions).to.contain("dÖ");
+        expect(suggestions).to.contain("dÕ");
+        expect(suggestions).to.contain("dÔ");
+        done();
+      });
+    });
+
+    it("shows suggestions for 'ú', 'ù', 'ü', 'û', 'Ú', 'Ù', 'Ü', 'Û'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dú dù dü dû dÚ dÙ dÜ dÛ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('du');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dú");
+        expect(suggestions).to.contain("dù");
+        expect(suggestions).to.contain("dü");
+        expect(suggestions).to.contain("dû");
+        expect(suggestions).to.contain("dÚ");
+        expect(suggestions).to.contain("dÙ");
+        expect(suggestions).to.contain("dÜ");
+        expect(suggestions).to.contain("dÛ");
+        done();
+      });
+    });
+
+    it("shows suggestions for 'ç', 'Ç'", function(done){
+      var outer$ = helper.padOuter$;
+
+      // write words with Latin characters, so they will be available on suggestions later
+      // (all start with "d" so we can use this prefix to choose which suggestions to show)
+      var $lastLine = getLine(3);
+      $lastLine.sendkeys('dç dÇ ');
+
+      // type first letters, so all words written above should be displayed
+      $lastLine.sendkeys('dc');
+
+      helper.waitFor(function(){
+        return outer$('div#autocomp').is(":visible");
+      }).done(function(){
+        var suggestions = autocompleteHelper.textsOf(outer$('div#autocomp li'));
+        expect(suggestions).to.contain("dç");
+        expect(suggestions).to.contain("dÇ");
+        done();
+      });
+    });
+  });
+
 
 });
 

--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -47,14 +47,14 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
   it("applies selected suggestion when user presses ENTER", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
-    var $lastLine =  getLine(3);
+    var $lastLine =  autocompleteHelper.getLine(3);
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
     }).done(function(){
       autocompleteHelper.pressEnter();
       helper.waitFor(function(){
-        var $lastLine =  getLine(3);
+        var $lastLine =  autocompleteHelper.getLine(3);
         return $lastLine.text() === "car";
       }).done(done);
     });
@@ -91,14 +91,14 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       autocompleteHelper.addAttributeToLine(0, function(){
         var outer$ = helper.padOuter$;
         var inner$ = helper.padInner$;
-        var $lastLine =  getLine(3);
+        var $lastLine =  autocompleteHelper.getLine(3);
         $lastLine.sendkeys('c');
         helper.waitFor(function(){
           return outer$('div#autocomp').is(":visible");
         }).done(function(){
           autocompleteHelper.pressEnter();
           helper.waitFor(function(){
-            var $lastLine =  getLine(3);
+            var $lastLine =  autocompleteHelper.getLine(3);
             return $lastLine.text() === "car";
           }).done(done);
         });
@@ -133,7 +133,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       autocomp.processKeyEvent = false;
 
       //show suggestions box
-      var $lastLine =  getLine(3);
+      var $lastLine =  autocompleteHelper.getLine(3);
       $lastLine.sendkeys('c');
       helper.waitFor(function(){
         return outer$('div#autocomp').is(":visible");
@@ -143,7 +143,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
         //verify key event was ignored
         setTimeout(function(){
-          var $lastLine =  getLine(3);
+          var $lastLine =  autocompleteHelper.getLine(3);
           expect($lastLine.text()).to.be("c");
           done();
         }, 500);
@@ -223,7 +223,31 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       }).done(done);
     });
 
+    it("applies suggestion word", function(done){
+      //change the first line to a list
+      autocompleteHelper.addAttributeToLine(0, function(){
+        var outer$ = helper.padOuter$;
+        var $lastLine =  autocompleteHelper.getLine(0);
+        // let the line empty
+        $lastLine.sendkeys('{selectall}{backspace}');
+
+        helper.waitFor(function(){
+          return outer$('div#autocomp').is(":visible");
+        }).done(function(){
+          // select first option "chrome"
+          autocompleteHelper.pressEnter();
+          helper.waitFor(function(){
+            var $firstLine =  autocompleteHelper.getLine(0);
+            var $firstItem = $firstLine.find("ul li").text();
+            return $firstItem === "chrome";
+          }).done(done);
+        });
+      });
+    });
+
   });
+
+
 
   context("when suggestions are not case sensitive", function(){
 
@@ -234,7 +258,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     })
 
     it("shows suggestions in uppercase and lowercase", function(done){
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       var outer$ = helper.padOuter$;
       //write CAR in the last line, duplicated word uppercase
       $lastLine.sendkeys('CAR CA');
@@ -267,7 +291,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dá dà dä dã dâ dÁ dÀ dÄ dÃ dÂ ');
 
       // type first letters, so all words written above should be displayed
@@ -296,7 +320,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dé dè dë dê dÉ dÈ dË dÊ ');
 
       // type first letters, so all words written above should be displayed
@@ -323,7 +347,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dí dì dï dî dÍ dÌ dÏ dÎ ');
 
       // type first letters, so all words written above should be displayed
@@ -350,7 +374,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dó dò dö dõ dô dÓ dÒ dÖ dÕ dÔ ');
 
       // type first letters, so all words written above should be displayed
@@ -379,7 +403,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dú dù dü dû dÚ dÙ dÜ dÛ ');
 
       // type first letters, so all words written above should be displayed
@@ -406,7 +430,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
       // write words with Latin characters, so they will be available on suggestions later
       // (all start with "d" so we can use this prefix to choose which suggestions to show)
-      var $lastLine = getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
       $lastLine.sendkeys('dç dÇ ');
 
       // type first letters, so all words written above should be displayed
@@ -449,15 +473,14 @@ var autocompleteHelper = {
 
   addAttributeToLine: function(lineNum, cb){
     var inner$ = helper.padInner$;
-    var $targetLine = getLine(lineNum);
+    var $targetLine = this.getLine(lineNum);
     $targetLine.sendkeys('{mark}');
     this.pressListButton();
     helper.waitFor(function(){
-      var $targetLine = getLine(lineNum);
+      var $targetLine = autocompleteHelper.getLine(lineNum);
       return $targetLine.find("ul li").length === 1;
     }).done(cb);
   },
-
   // first line === getLine(0);
   // second line === getLine(1);
   // ...

--- a/static/tests/frontend/specs/utils.js
+++ b/static/tests/frontend/specs/utils.js
@@ -3,8 +3,8 @@ var writeWordsWithC = function(cb){
   var inner$ = helper.padInner$;
   var $firstTextElement = inner$("div").first();
   //select this text element
-  $firstTextElement.sendkeys('{selectall}');
-  $firstTextElement.sendkeys('car{enter}chrome{enter}couch{enter}{enter}');
+  $firstTextElement.sendkeys('{selectall}{del}');
+  $firstTextElement.html('car<br/>chrome<br/>couch<br/><br/>');
   helper.waitFor(function(){
     var $firstTextElement =  inner$("div").first();
     return $firstTextElement.text() === "car";


### PR DESCRIPTION
- new flag to allow Latin chars to be ignored when suggesting words (ex: type "a" and get suggestions like "árvore");
- bug fix: avoid capturing "(" (shift+9) when suggestion box is displayed;
- bug fix: when flag to allow suggestions for empty word is `on` and line has line attributes (like being an unordered list), the line attribute was being removed.