### PR TITLE
Allow clicking list items

### DIFF
--- a/static/css/autocomp.css
+++ b/static/css/autocomp.css
@@ -19,8 +19,8 @@
 	min-width: 45px;
 }
 
-#autocomp:hover li{
-	opacity:0.2; /*to indicate that they are not clickable. See https://github.com/jdittrich/ep_autocomp/issues/3*/
+#autocomp li:hover{
+	opacity: 0.6;
 }
 
 #autocomp li.selected{

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -41,14 +41,11 @@ var autocomp = {
   resetPostSuggestionSelectedCallbacks: function() {
     this.postSuggestionSelectedCallbacks = [];
   },
-  callPostSuggestionSelectedCallbacks: function(done) {
+  callPostSuggestionSelectedCallbacks: function() {
     _.each(this.postSuggestionSelectedCallbacks, function(callback) {
       callback();
     });
-
-    done();
   },
-
 
 	config:{
 		//move this ot external JSON. Save Regexes as Strings, parse them when needed.
@@ -253,10 +250,9 @@ var autocomp = {
     if(textToInsert !== undefined){
       // register listener to be able to call all callbacks when sendkeys is done
       $(currentElement).on("sendkeys", function() {
-        autocomp.callPostSuggestionSelectedCallbacks(function() {
-          // unregister listener to avoid duplicate calls in the future
-          $(currentElement).off("sendkeys");
-        });
+        // unregister listener to avoid duplicate calls in the future
+        $(currentElement).off("sendkeys");
+        autocomp.callPostSuggestionSelectedCallbacks();
       });
       // Empty lines always have a <br>, so due to problems with inserting text
       // with sendkeys, in this case, we need to insert the html directly

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -71,8 +71,8 @@ var autocomp = {
 			autocomp.tempDisabled=false;
 		},100);
 	},
-	//showAutocomp:function(){},
-	createAutocompHTML:function(filteredSuggestions,cursorPosition){
+
+	createAutocompHTML: function(filteredSuggestions, caretPosition, context){
 	/*
 	creates the dom element for the menu.
 
@@ -82,41 +82,55 @@ var autocomp = {
 			fullText: string containing the full text, e.g. "nightingale"
 			complementaryString: string with what is needed to complete the String to be matched e.g is the string to be matches is "nighti", than the complementary String here would be "ngale"
 		}
-	cursorPosition: an getBoundingClientRect() with the properties top and left in pixel.
+	caretPosition: an getBoundingClientRect() with the properties top and left in pixel.
 
 	returns: ?
 	*/
-		if(!filteredSuggestions||!cursorPosition){
+		if(!filteredSuggestions || !caretPosition){
 			console.log("insufficent attributes");
-			return;} //precaution
-		if(filteredSuggestions.length===0){
+			return;
+    } //precaution
+
+		if(filteredSuggestions.length === 0){
 			$autocomp.hide();
 		}
-
 
 		$list.empty();
 
 		//CREATE DOM ELEMENTS
 		var listEntries = [];
-		$.each(filteredSuggestions, function(index,suggestion){
+		$.each(filteredSuggestions, function(index, suggestion){
 			// create a dom element (li) for each suggestion
-			listEntries.push(
-				$("<li/>",{
-					"class":"ep_autocomp-listentry",
-					"text":suggestion.fullText
-				}).data(
-					"complementary",suggestion.complementaryString //give the complementary string along.
-				)//end $
-			); //end push
+      var listEntry = $("<li/>",
+        {
+          "class": "ep_autocomp-listentry",
+          "text": suggestion.fullText
+        }).data(
+          "complementary", suggestion.complementaryString //give the complementary string along.
+        );
+
+        // add listener to select suggestion on click
+        listEntry.click(function() {
+          // replace current selected suggestion with this entry
+          $(this).siblings(".selected").removeClass("selected");
+          $(this).addClass("selected");
+
+          // replace text with this suggestion
+          autocomp.selectSuggestion(context);
+        });
+			listEntries.push(listEntry);
 		}); //end each-function
+
+    // make first suggestion marked as selected
 		$(listEntries[0]).addClass("selected");
 
-		$list.append(listEntries); //...append all list entries holding the suggestions
-		//appendTo($('iframe[name="ace_outer"]').contents().find('#outerdocbody'));//append to dom //remove this
+    // append all list entries holding the suggestions
+		$list.append(listEntries);
 
+    // show suggestions next to caret position
 		$autocomp
 			.show()
-			.css({top: cursorPosition.top, left: cursorPosition.left});
+			.css({top: caretPosition.top, left: caretPosition.left});
 	},
 
 	aceKeyEvent: function(type, context, cb){
@@ -133,7 +147,7 @@ var autocomp = {
 
 		//if key is ↑ , choose next option, prevent default
 		//if key is ↓ , choose next option, prevent default
-		//if key is ENTER, read out the complementation, close autocomplete menu and input it at cursor. It will reopen tough, if there is still something to complete. No problem, on a " " or any other non completable character and it is gone again.
+		//if key is ENTER, read out the complementation, close autocomplete menu and input it at caret. It will reopen tough, if there is still something to complete. No problem, on a " " or any other non completable character and it is gone again.
 		if($autocomp.is(":visible")){
 			//ENTER PRESSED
 			if(this.enterPressed(context.evt)){
@@ -234,7 +248,7 @@ var autocomp = {
   selectSuggestion:function(context){
     var suggestionFound = false;
     var textToInsert = $list.children(".selected").eq(0).data("complementary"); //get the data out of the currently selected element
-    //the element the cursor is in
+    //the element the caret is in
     var currentElement = context.rep.lines.atIndex(context.rep.selEnd[0]).lineNode;
     if(textToInsert !== undefined){
       // register listener to be able to call all callbacks when sendkeys is done
@@ -300,8 +314,8 @@ var autocomp = {
 			return;
 		}
 
-		var cursorPosition = autocomp.cursorPosition(context);
-		autocomp.createAutocompHTML(filteredSuggestions,cursorPosition);
+		var caretPosition = autocomp.caretPosition(context);
+		autocomp.createAutocompHTML(filteredSuggestions, caretPosition, context);
 	},
 	filterSuggestionList:function(partialWord,possibleSuggestions){
 		/*
@@ -388,10 +402,10 @@ var autocomp = {
       replace(/[Ç]/g, "C");
   },
 
-	cursorPosition:function(context){
+	caretPosition:function(context){
 		/*
 		gets: context object from a ace editor event (e.g. aceEditEvent)
-		returns: x and y value for the position of the cursor measured in pixel.
+		returns: x and y value for the position of the caret measured in pixel.
 		Should work in any other context too (if you need that functionality in another etherpad addon)
 
 		useful to know:
@@ -407,8 +421,8 @@ var autocomp = {
           took place, many spans if a lot of different bold, colored etc. text is there. But: the amount of nesting varies
           (one span may have a <b>, in which is a <i> etc. and instead of spans we may have code or the like as well.
 
-		In this function, we will determine the div the cursor is in and clone that div and its style. Than, in the clone, we find
-    the corresponding subnode the cursor is in, than the offset in the corresponding text node the cursor is in.
+		In this function, we will determine the div the caret is in and clone that div and its style. Than, in the clone, we find
+    the corresponding subnode the caret is in, than the offset in the corresponding text node the caret is in.
 		Than we insert a span exactly there and get its position.
 		Than we clean up again, cause this is messy stuff.
 		*/
@@ -418,13 +432,13 @@ var autocomp = {
     var $cloneChildNode = this.cloneNodeWithStyle($childNode);
 
 		//
-		// In the following section we insert a DOM node where the cursor is.
+		// In the following section we insert a DOM node where the caret is.
 		//
 
-    //how many characters are between the start of the element and the cursor?
+    //how many characters are between the start of the element and the caret?
 		var leftoverString = $cloneChildNode.text().length - (counter - context.rep.selEnd[1]);
-    var targetNode = $cloneChildNode[0].childNodes[0]; // the subnode our cursor is in.
-		var targetNodeText = targetNode.nodeValue || ""; //get the text of the subnode our cursor is in.
+    var targetNode = $cloneChildNode[0].childNodes[0]; // the subnode our caret is in.
+		var targetNodeText = targetNode.nodeValue || ""; //get the text of the subnode our caret is in.
 
 		var span = document.createElement("span"); //create a helper span to be inserted later
 		span.appendChild(document.createTextNode('X'));//…and give it a content.
@@ -435,46 +449,46 @@ var autocomp = {
 		// Remove the existing text
 		$cloneChildNode.text("");
 
-		// reinsert the text, but with the additional node at cursor position
+		// reinsert the text, but with the additional node at caret position
 
-		$cloneChildNode[0].appendChild(document.createTextNode(textBeforeCaret)); //insert text before cursor
-		$cloneChildNode[0].appendChild(span); //insert element at cursor position.
-		$cloneChildNode[0].appendChild(document.createTextNode(textAfterCaret)); //insert text after cursor
+		$cloneChildNode[0].appendChild(document.createTextNode(textBeforeCaret)); //insert text before caret
+		$cloneChildNode[0].appendChild(span); //insert element at caret position.
+		$cloneChildNode[0].appendChild(document.createTextNode(textAfterCaret)); //insert text after caret
 
-		$cloneChildNode.appendTo($('iframe[name="ace_outer"]').contents().find('#outerdocbody')); //In order to see where the node we added that the cursor position is, we need to insert it into the document. We do not append it in the inner editor (messes with ace), but put it in the outer one.
+		$cloneChildNode.appendTo($('iframe[name="ace_outer"]').contents().find('#outerdocbody')); //In order to see where the node we added that the caret position is, we need to insert it into the document. We do not append it in the inner editor (messes with ace), but put it in the outer one.
 
-		var cursorPosition = $(span).offset(); //now we get the position of the element which was inserted at the cursor position
+		var caretPosition = $(span).offset(); //now we get the position of the element which was inserted at the caret position
 		var scrollYPos = $('iframe[name="ace_outer"]').contents().scrollTop(); //get scroll position to take it into account.
 
 		$cloneChildNode.remove(); //clean up again.
 
 		return {
-			top: (cursorPosition.top + scrollYPos), //so offset gives me the ofset to the root document (not the iframe) so after scrolling down, top becomes less or even negative. So add the offset to get back where it belongs.
-			left:cursorPosition.left
+			top: (caretPosition.top + scrollYPos), //so offset gives me the ofset to the root document (not the iframe) so after scrolling down, top becomes less or even negative. So add the offset to get back where it belongs.
+			left:caretPosition.left
 		};
 	},
 
   getNodeInfoWhereCaretIs: function(context){
     var caretPosition = context.rep.selEnd; //get caret position as array, [0] is y, [1] is x;
     var caretColumn = caretPosition[1];
-    var $cursorDiv = $(context.rep.lines.atIndex(caretPosition[0]).domInfo.node); //determine the node the cursor is in
+    var $caretDiv = $(context.rep.lines.atIndex(caretPosition[0]).domInfo.node); //determine the node the caret is in
 
     //$textNodes than holds all text nodes that are found inside the div (in the same order as in the document hopefully!)
-    var $textNodes = $cursorDiv.find("*").contents().filter(function() {
+    var $textNodes = $caretDiv.find("*").contents().filter(function() {
       return this.nodeType === 3;
     });
 
-    //now we want to find the text node the cursor is in.
+    //now we want to find the text node the caret is in.
     var counter = 0; //holds the added length of text of all text nodes parsed so far. Non parsed yet, so it's 0.
-    var $childNode = null; //the subnode our cursor is in.
+    var $childNode = null; //the subnode our caret is in.
 
-    //find the child node the cursor is in
+    //find the child node the caret is in
     $textNodes.each(function(index,element){
       counter = counter + element.textContent.length; //add up to the length of text nodes parsed.
       //…current subnode. It can be put in the if clause as well, *but* if none is found that we would need to failsave this somewhere else
       $childNode = $(element.parentNode);
 
-      //if the added text length of all text parsed is now  grater than the cursors position.
+      //if the added text length of all text parsed is now  grater than the carets position.
       //using some plugins with neseted structures, it may be a bit off (to correct, substracting from selEnd[1] would be needed.
       if(counter >= caretColumn){
         return false; //stop .each by returning false
@@ -482,11 +496,11 @@ var autocomp = {
     });
 
     if ($childNode === null) {
-      // There was no text node inside $cursorDiv, so caret is on an empty line.
+      // There was no text node inside $caretDiv, so caret is on an empty line.
       // Empty lines on Etherpad always have a <br>, so we get its parent.
       // We cannot use br itself because if we insert a span inside the br we
       // get weird positions on screen
-      $childNode = $cursorDiv.find("br").parent();
+      $childNode = $caretDiv.find("br").parent();
     }
 
     return {

--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -2,8 +2,10 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
   beforeEach(function(cb){
     helper.newPad(function(){
-      resetFlagsAndEnableAutocomplete(function(){
-        writeWordsWithC(cb);
+      clearPad(function() {
+        resetFlagsAndEnableAutocomplete(function(){
+          writeWordsWithC(cb);
+        });
       });
     });
     this.timeout(60000);
@@ -14,6 +16,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
     var $lastLine =  inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -31,6 +34,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
     // first make sure suggestions are displayed
     var $lastLine =  inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -47,15 +51,41 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
   it("applies selected suggestion when user presses ENTER", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
-    var $lastLine =  autocompleteHelper.getLine(3);
+    var $lastLine = autocompleteHelper.getLine(3);
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
     }).done(function(){
       autocompleteHelper.pressEnter();
       helper.waitFor(function(){
-        var $lastLine =  autocompleteHelper.getLine(3);
+        var $lastLine = autocompleteHelper.getLine(3);
         return $lastLine.text() === "car";
+      }).done(done);
+    });
+  });
+
+  it("applies selected suggestion when clicks on it on the suggestion box", function(done){
+    var outer$ = helper.padOuter$;
+    var inner$ = helper.padInner$;
+
+    // type something to show suggestions
+    var $lastLine = autocompleteHelper.getLine(3);
+    $lastLine.sendkeys('{selectall}');
+    $lastLine.sendkeys('c');
+
+    helper.waitFor(function(){
+      return outer$('div#autocomp').is(":visible");
+    }).done(function(){
+      // click on last suggestion ("couch")
+      var $suggestions = outer$('div#autocomp li');
+      var $couchSuggestion = $suggestions.last();
+      $couchSuggestion.click();
+
+      // check if last suggestion was inserted
+      helper.waitFor(function(){
+        var $lastLine = autocompleteHelper.getLine(3);
+        return $lastLine.text() === "couch";
       }).done(done);
     });
   });
@@ -64,6 +94,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
     var $lastLine =  inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -91,14 +122,15 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       autocompleteHelper.addAttributeToLine(0, function(){
         var outer$ = helper.padOuter$;
         var inner$ = helper.padInner$;
-        var $lastLine =  autocompleteHelper.getLine(3);
+        var $lastLine = autocompleteHelper.getLine(3);
+        $lastLine.sendkeys('{selectall}');
         $lastLine.sendkeys('c');
         helper.waitFor(function(){
           return outer$('div#autocomp').is(":visible");
         }).done(function(){
           autocompleteHelper.pressEnter();
           helper.waitFor(function(){
-            var $lastLine =  autocompleteHelper.getLine(3);
+            var $lastLine = autocompleteHelper.getLine(3);
             return $lastLine.text() === "car";
           }).done(done);
         });
@@ -114,6 +146,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       autocomp.processEditEvent = false;
       var inner$ = helper.padInner$;
       var $lastLine =  inner$("div").last();
+      $lastLine.sendkeys('{selectall}');
       $lastLine.sendkeys('c');
       //we have to give enough time to suggestions box be shown
       setTimeout(function() {
@@ -133,7 +166,8 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       autocomp.processKeyEvent = false;
 
       //show suggestions box
-      var $lastLine =  autocompleteHelper.getLine(3);
+      var $lastLine = autocompleteHelper.getLine(3);
+      $lastLine.sendkeys('{selectall}');
       $lastLine.sendkeys('c');
       helper.waitFor(function(){
         return outer$('div#autocomp').is(":visible");
@@ -143,7 +177,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
         //verify key event was ignored
         setTimeout(function(){
-          var $lastLine =  autocompleteHelper.getLine(3);
+          var $lastLine = autocompleteHelper.getLine(3);
           expect($lastLine.text()).to.be("c");
           done();
         }, 500);
@@ -153,7 +187,9 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
   context("when current line has line attribute", function(){
     beforeEach(function(cb) {
-      autocompleteHelper.getLine(3).sendkeys("c");
+      var $lastLine = autocompleteHelper.getLine(3);
+      $lastLine.sendkeys('{selectall}');
+      $lastLine.sendkeys("c");
       autocompleteHelper.addAttributeToLine(3, cb);
     });
 
@@ -164,7 +200,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
         var inner$ = helper.padInner$;
 
         //using contents was the only way we found to set content of a list item
-        var $lastLine =  inner$("div").last().find("ul li").contents();
+        var $lastLine = inner$("div").last().find("ul li").contents();
 
         $lastLine.sendkeys('a');
         helper.waitFor(function(){
@@ -210,10 +246,10 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       cb();
     });
 
-    it("displays suggestions without having to type anything", function(done) {
+    it("displays suggestions without having to type a word", function(done) {
       var outer$ = helper.padOuter$;
       var inner$ = helper.padInner$;
-      var $lastLine =  inner$("div").last();
+      var $lastLine = inner$("div").last();
 
       // type something to display suggestions
       $lastLine.sendkeys(" ");
@@ -247,10 +283,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
   });
 
-
-
   context("when suggestions are not case sensitive", function(){
-
     // disable case sensitive matches
     beforeEach(function(){
       var autocomp = helper.padChrome$.window.autocomp;
@@ -258,9 +291,11 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     })
 
     it("shows suggestions in uppercase and lowercase", function(done){
-      var $lastLine = autocompleteHelper.getLine(3);
       var outer$ = helper.padOuter$;
+
       //write CAR in the last line, duplicated word uppercase
+      var $lastLine = autocompleteHelper.getLine(3);
+      $lastLine.sendkeys('{selectall}');
       $lastLine.sendkeys('CAR CA');
 
       helper.waitFor(function(){

--- a/static/tests/frontend/specs/navigation.js
+++ b/static/tests/frontend/specs/navigation.js
@@ -2,8 +2,10 @@ describe("ep_autocomp - commands auto complete", function(){
   //create a new pad before each test run
   beforeEach(function(cb){
     helper.newPad(function(){
-      resetFlagsAndEnableAutocomplete(function(){
-        writeWordsWithC(cb);
+      clearPad(function() {
+        resetFlagsAndEnableAutocomplete(function(){
+          writeWordsWithC(cb);
+        });
       });
     });
     this.timeout(60000);
@@ -15,6 +17,7 @@ describe("ep_autocomp - commands auto complete", function(){
 
     // opens suggestions box
     var $lastLine =  inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -35,6 +38,7 @@ describe("ep_autocomp - commands auto complete", function(){
 
     // opens suggestions box
     var $lastLine =  inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -57,6 +61,7 @@ describe("ep_autocomp - commands auto complete", function(){
     var inner$ = helper.padInner$;
     // opens suggestions box
     var $lastLine = inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");
@@ -80,6 +85,7 @@ describe("ep_autocomp - commands auto complete", function(){
     var inner$ = helper.padInner$;
     // opens suggestions box
     var $lastLine = inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     helper.waitFor(function(){
       return outer$('div#autocomp').is(":visible");

--- a/static/tests/frontend/specs/utils.js
+++ b/static/tests/frontend/specs/utils.js
@@ -1,16 +1,28 @@
 var writeWordsWithC = function(cb){
-
   var inner$ = helper.padInner$;
   var $firstTextElement = inner$("div").first();
   //select this text element
   $firstTextElement.sendkeys('{selectall}{del}');
-  $firstTextElement.html('car<br/>chrome<br/>couch<br/><br/>');
+  $firstTextElement.html('car<br/>chrome<br/>couch<br/>&nbsp;<br/>');
   helper.waitFor(function(){
     var $firstTextElement =  inner$("div").first();
     return $firstTextElement.text() === "car";
   }).done(cb);
 }
 
+// force pad content to be empty, so tests won't fail if Etherpad default text
+// has content on settings.json
+var clearPad = function(cb) {
+  var inner$ = helper.padInner$;
+  var $padContent = inner$("#innerdocbody");
+  $padContent.html("");
+
+  // wait for Etherpad to re-create first line
+  helper.waitFor(function(){
+    var lineNumber = inner$("div").length;
+    return lineNumber === 1;
+  }).done(cb);
+}
 
 var enableAutocomplete = function(callback) {
   var chrome$ = helper.padChrome$;
@@ -28,7 +40,6 @@ var enableAutocomplete = function(callback) {
 
   callback();
 }
-
 
 var resetFlagsAndEnableAutocomplete = function(callback) {
   resetFlags();


### PR DESCRIPTION
I could not reproduce the issue @jdittrich mentioned on #3. Tested on
Chrome on a Mac, so I'm assuming this commit addresses what was
mentioned on #3.

This commit also rename all occurrences of "cursor" I could find to
"caret" ("cursor" is related to mouse, "caret" to keyboard. See README
of https://github.com/redhog/ep_cursortrace);

Also improved some tests and avoided errors when Etherpad instance has
default pad text set on settings.json.