### PR TITLE
Remove tempDisabledHelper + bug fix + minor improvements

### DIFF
--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -168,6 +168,7 @@ var autocomp = {
 
     //SPACE AND CONTROL PRESSED
     if(this.ctrlSpacePressed(context.evt)){
+      context.evt.preventDefault();
       if($autocomp.is(":hidden")){
         this.update(context);
       }else{

--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -134,6 +134,7 @@ var autocomp = {
     //if key is ↑ , choose next option, prevent default
     //if key is ↓ , choose next option, prevent default
     //if key is ENTER, read out the complementation, close autocomplete menu and input it at caret. It will reopen tough, if there is still something to complete. No problem, on a " " or any other non completable character and it is gone again.
+    var eventProcessed = false;
     if($autocomp.is(":visible")){
       //ENTER PRESSED
       if(this.enterPressed(context.evt)){
@@ -142,7 +143,7 @@ var autocomp = {
           context.evt.preventDefault();
           // return value should be true if the event was handled.
           // So we return true which can be returned by the hook itself consequently.
-          return true;
+          eventProcessed = true;
         }
       }
 
@@ -150,32 +151,38 @@ var autocomp = {
       if(this.upPressed(context.evt)){
         this.moveSelectionUp();
         context.evt.preventDefault();
-        return true;
+        eventProcessed = true;
       }
       //DOWN PRESSED
       if(this.downPressed(context.evt)){
         this.moveSelectionDown();
         context.evt.preventDefault();
-        return true;
+        eventProcessed = true;
       }
       //ESCAPE PRESSED
       if(this.escPressed(context.evt)){
         this.closeSuggestionBox();
         context.evt.preventDefault();
-        return true;
+        eventProcessed = true;
       }
     }
 
     //SPACE AND CONTROL PRESSED
     if(this.ctrlSpacePressed(context.evt)){
-      context.evt.preventDefault();
       if($autocomp.is(":hidden")){
         this.update(context);
       }else{
         this.closeSuggestionBox();
       }
-      return true;
+      eventProcessed = true;
     }
+
+    // did we process the event? If so, prevent default action
+    if (eventProcessed) {
+      context.evt.preventDefault();
+    }
+
+    return eventProcessed;
   },
   enterPressed: function(evt) {
     return evt.type === "keydown" && evt.keyCode === 13;

--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -29,6 +29,9 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
   });
 
   it("hides suggestions when user types a word that does not match any other from the text", function(done){
+    // this is a longer test, give it more time to run
+    this.timeout(5000);
+
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
 
@@ -44,7 +47,7 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
       $lastLine.sendkeys('notSavedWord');
       helper.waitFor(function(){
         return !outer$('div#autocomp').is(":visible");
-      }).done(done);
+      }, 2000).done(done);
     });
   });
 


### PR DESCRIPTION
By checking `context.evt.type === "keydown"`, we are able to avoid duplicate processing of key events, so `tempDisabledHelper` is not necessary anymore.

I've also fixed an issue when user presses Ctrl+space on a machine where space is configured to scroll page down (was happening on my Mac, using Chrome) -- suggestions were shown, but page was scrolling down, which was a bad experience.

Finally, I've made some minor organizations on the code