### PR TITLE
Fix bug of keeping scroll position when change selection

### DIFF
--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -118,6 +118,7 @@ var autocomp = {
     // show suggestions next to caret position
     $autocomp
       .show()
+      .scrollTop(0) // does not keep previous scroll position
       .css({top: caretPosition.top, left: caretPosition.left});
   },
 


### PR DESCRIPTION
To reproduce this bug:

1. Type lots of items beginning with a same letter (e.g. 'c')
(Make sure the quantity is enough to show a vertical scroll
in the suggestion list)
2. In the last line, type ('c') to force to show the suggestion list.
3. Select the last element in the suggestion list using arrow down.
4. Put the caret in another line
5. Put the caret in after the 'c' in the last line.
This should show the suggestion list with the scroll set in the step 3,
making the first option in the suggestion list not visible.
