### PR TITLE
Complement #19: Use a more defensive approach to test if suggestion matches custom regex

### DIFF
--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -695,7 +695,8 @@ var autocomp = {
     var caretColumnPosition = this.getCaretColumnOnline(context);
     var currentLine         = this.getCurrentLine(context);
     var textBeforeCaret     = currentLine.slice(0,caretColumnPosition); //from beginning until caret
-    var partialWord         = textBeforeCaret.match(sectionMarker)[index];
+    var regexMatches        = textBeforeCaret.match(sectionMarker);
+    var partialWord         = regexMatches ? regexMatches[index] : "";
     return partialWord;
   },
   hasMarker:function(context, line){


### PR DESCRIPTION
The default regex always matches something, but for custom regex that
might not be the case. So we use a safer approach to test if suggestion
matches the regex when filtering suggestions.