### PR TITLE
Store line number that made suggestion box be opened

### DIFF
--- a/static/js/autocomp.js
+++ b/static/js/autocomp.js
@@ -33,6 +33,8 @@ var autocomp = {
   // (user types "a" and we show suggestions like "ál", "ão", etc.)
   ignoreLatinCharacters: false,
 
+  tagetLine: undefined,
+
   // collection of callbacks to be called after user selects a suggestion from the list
   postSuggestionSelectedCallbacks: {},
   addPostSuggestionSelectedCallback: function(id, callback) {
@@ -80,6 +82,8 @@ var autocomp = {
     if(filteredSuggestions.length === 0){
       this.closeSuggestionBox();
     }
+
+    this.targetLine = context.rep.selEnd[0];
 
     $list.empty();
 
@@ -349,7 +353,8 @@ var autocomp = {
     }
   },
 
-  closeSuggestionBox:function(){
+  closeSuggestionBox:function(context){
+    this.targetLine = undefined;
     $autocomp.hide();
   },
   aceEditEvent:function(type, context, cb){

--- a/static/tests/frontend/specs/navigation.js
+++ b/static/tests/frontend/specs/navigation.js
@@ -30,7 +30,7 @@ describe("ep_autocomp - commands auto complete", function(){
       expect(selectedSuggestion.text()).to.be("chrome");
       done();
     });
-  })
+  });
 
   it("moves selection to a position above", function(done){
     var outer$ = helper.padOuter$;
@@ -55,7 +55,8 @@ describe("ep_autocomp - commands auto complete", function(){
       expect(selectedSuggestion.text()).to.be("chrome");
       done();
     });
-  })
+  });
+
   it("selects suggestion", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
@@ -67,7 +68,7 @@ describe("ep_autocomp - commands auto complete", function(){
       return outer$('div#autocomp').is(":visible");
     }).done(function() {
       var $lastLine = inner$('div').last();
-      var context = ep_autocomp_test_helper.navigation.mockContext($lastLine);
+      var context = ep_autocomp_test_helper.utils.mockContext($lastLine);
 
       // force autocomplete to select first option
       var autocomp = helper.padChrome$.window.autocomp;
@@ -78,7 +79,7 @@ describe("ep_autocomp - commands auto complete", function(){
         return $lastLine.text() === "car";
       }).done(done);
     });
-  })
+  });
 
   it("closes suggestions box without replacing the text", function(done){
     var outer$ = helper.padOuter$;
@@ -102,25 +103,7 @@ describe("ep_autocomp - commands auto complete", function(){
         done();
       });
     });
-  })
-})
+  });
+});
 
 var ep_autocomp_test_helper = ep_autocomp_test_helper || {};
-ep_autocomp_test_helper.navigation = {
-  mockContext: function($currentElement){
-    var context = {
-      rep: {
-        lines: {
-          atIndex: function(i) {
-            return {
-              lineNode: $currentElement[0],
-              domInfo: { node: $currentElement[0] },
-            }
-          }
-        },
-        selEnd: [1, 1],
-      }
-    }
-    return context;
-  }
-}

--- a/static/tests/frontend/specs/targetLine.js
+++ b/static/tests/frontend/specs/targetLine.js
@@ -1,0 +1,84 @@
+describe("ep_autocomp - target line", function(){
+  //create a new pad before each test run
+  beforeEach(function(cb){
+    helper.newPad(function(){
+      ep_autocomp_test_helper.utils.clearPad(function() {
+        ep_autocomp_test_helper.utils.resetFlagsAndEnableAutocomplete(function(){
+          ep_autocomp_test_helper.utils.writeWordsWithC(cb);
+        });
+      });
+    });
+    this.timeout(60000);
+  });
+
+  it("updates target line when suggestions box is opened", function(done){
+    var outer$ = helper.padOuter$;
+    var inner$ = helper.padInner$;
+    var autocomp = helper.padChrome$.window.autocomp;
+    var targetLine = 3;
+
+    // opens suggestions box
+    var $lastLine = ep_autocomp_test_helper.utils.getLine(targetLine);
+    $lastLine.sendkeys('{selectall}');
+    $lastLine.sendkeys('c');
+
+    // wait for targetLine to be updated
+    helper.waitFor(function(){
+      return autocomp.targetLine;
+    }).done(function() {
+      expect(autocomp.targetLine).to.be(targetLine);
+
+      done();
+    });
+  });
+
+  it("resets target line when suggestion is selected", function(done){
+    var outer$ = helper.padOuter$;
+    var inner$ = helper.padInner$;
+    var autocomp = helper.padChrome$.window.autocomp;
+
+    // opens suggestions box
+    var $lastLine = inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
+    $lastLine.sendkeys('c');
+    helper.waitFor(function(){
+      return autocomp.targetLine !== undefined;
+    }).done(function() {
+      var $lastLine = inner$('div').last();
+      var context = ep_autocomp_test_helper.utils.mockContext($lastLine);
+
+      // force autocomplete to select suggestion
+      var autocomp = helper.padChrome$.window.autocomp;
+      autocomp.selectSuggestion(context);
+
+      // wait for targetLine to be updated
+      helper.waitFor(function(){
+        return autocomp.targetLine === undefined;
+      }).done(done);
+    });
+  });
+
+  it("resets target line when suggestions box is manually closed", function(done){
+    var outer$ = helper.padOuter$;
+    var inner$ = helper.padInner$;
+    var autocomp = helper.padChrome$.window.autocomp;
+
+    // opens suggestions box
+    var $lastLine = inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
+    $lastLine.sendkeys('c');
+    helper.waitFor(function(){
+      return autocomp.targetLine !== undefined;
+    }).done(function() {
+      // force autocomplete to close suggestions box
+      autocomp.closeSuggestionBox();
+
+      // wait for targetLine to be updated
+      helper.waitFor(function(){
+        return autocomp.targetLine === undefined;
+      }).done(done);
+    });
+  });
+});
+
+var ep_autocomp_test_helper = ep_autocomp_test_helper || {};

--- a/static/tests/frontend/specs/utils.js
+++ b/static/tests/frontend/specs/utils.js
@@ -111,5 +111,22 @@ ep_autocomp_test_helper.utils = {
       return $(el).text();
     })
     return texts;
-  }
+  },
+
+  mockContext: function($currentElement){
+    var context = {
+      rep: {
+        lines: {
+          atIndex: function(i) {
+            return {
+              lineNode: $currentElement[0],
+              domInfo: { node: $currentElement[0] },
+            }
+          }
+        },
+        selEnd: [1, 1],
+      }
+    }
+    return context;
+  },
 };


### PR DESCRIPTION
This is useful for other plugins that extend ep_autocomp, if they need a
reference of why suggestions were being displayed. We store line number
instead of the DOM element or the whole line (from rep.lines) because
those values are modified by Etherpad every time a change is made on the
pad. If we stored any of those values it would be impossible* to compare
them with the actual state of the pad.

*: or at least I did not find any way to do that.