### PR TITLE
[fix] Place suggestions next to caret when div has more than one line of text

### DIFF
--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -32,37 +32,34 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
 
   it("hides suggestions when user types a word that does not match any other from the text", function(done){
     var inner$ = helper.padInner$;
+    var test = this;
 
     // first make sure suggestions are displayed
     var $lastLine =  inner$("div").last();
     $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
-    utils.waitShowSuggestions(this, function(){
+    utils.waitShowSuggestions(test, function(){
       // then check if suggestions are hidden if there are no words that match
       var $lastLine =  inner$("div").last();
       $lastLine.sendkeys('notSavedWord');
-      helper.waitFor(function(){
-        var outer$ = helper.padOuter$;
-        return !outer$('div#autocomp').is(":visible");
-      }, 2000).done(done);
+      utils.waitHideSuggestions(test, done);
     });
   });
 
   it("hides suggestions when user types ESC", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
+    var test = this;
 
     // first make sure suggestions are displayed
     var $lastLine =  inner$("div").last();
     $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
-    utils.waitShowSuggestions(this, function(){
+    utils.waitShowSuggestions(test, function(){
       // then press ESC
       utils.pressEsc();
 
-      helper.waitFor(function(){
-        return !outer$('div#autocomp').is(":visible");
-      }).done(done);
+      utils.waitHideSuggestions(test, done);
     });
   });
 
@@ -216,6 +213,3 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     });
   });
 });
-
-/* ********** Helper functions ********** */
-var ep_autocomp_test_helper = ep_autocomp_test_helper || {};

--- a/static/tests/frontend/specs/navigation.js
+++ b/static/tests/frontend/specs/navigation.js
@@ -82,6 +82,8 @@ describe("ep_autocomp - commands auto complete", function(){
   it("closes suggestions box without replacing the text", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
+    var test = this;
+
     // opens suggestions box
     var $lastLine = inner$("div").last();
     $lastLine.sendkeys('{selectall}');
@@ -91,9 +93,7 @@ describe("ep_autocomp - commands auto complete", function(){
       var autocomp = helper.padChrome$.window.autocomp;
       autocomp.closeSuggestionBox();
 
-      helper.waitFor(function(){
-        return !outer$('div#autocomp').is(":visible");
-      }).done(function(){
+      utils.waitHideSuggestions(test, function(){
         var $lastLine =  inner$("div").last();
         expect($lastLine.text()).to.be("c");
         done();
@@ -101,5 +101,3 @@ describe("ep_autocomp - commands auto complete", function(){
     });
   });
 });
-
-var ep_autocomp_test_helper = ep_autocomp_test_helper || {};

--- a/static/tests/frontend/specs/pluginCustomization.js
+++ b/static/tests/frontend/specs/pluginCustomization.js
@@ -191,6 +191,3 @@ describe("ep_autocomp - plugin customization", function(){
     });
   });
 });
-
-/* ********** Helper functions ********** */
-var ep_autocomp_test_helper = ep_autocomp_test_helper || {};

--- a/static/tests/frontend/specs/pluginCustomizationLatinChars.js
+++ b/static/tests/frontend/specs/pluginCustomizationLatinChars.js
@@ -40,9 +40,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('da');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }, 4000).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dá");
       expect(suggestions).to.contain("dà");
@@ -70,9 +68,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('de');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dé");
       expect(suggestions).to.contain("dè");
@@ -98,9 +94,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('di');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dí");
       expect(suggestions).to.contain("dì");
@@ -126,9 +120,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('do');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dó");
       expect(suggestions).to.contain("dò");
@@ -156,9 +148,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('du');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dú");
       expect(suggestions).to.contain("dù");
@@ -184,9 +174,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so all words written above should be displayed
     $firstLine.sendkeys('dc');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dç");
       expect(suggestions).to.contain("dÇ");
@@ -207,9 +195,7 @@ describe("ep_autocomp - plugin customization - when flag to show suggestions for
     // type first chars, so some words written above should be displayed
     $firstLine.sendkeys('dá');
 
-    helper.waitFor(function(){
-      return outer$('div#autocomp').is(":visible");
-    }).done(function(){
+    utils.waitShowSuggestions(this, function(){
       var suggestions = utils.textsOf(outer$('div#autocomp li'));
       expect(suggestions).to.contain("dáo");
       expect(suggestions).to.not.contain("dào");

--- a/static/tests/frontend/specs/position.js
+++ b/static/tests/frontend/specs/position.js
@@ -1,0 +1,98 @@
+describe('ep_autocomp - position of autocomplete suggestions', function() {
+  var utils, targetLineNumber, baseline;
+
+  var getTargetLine = function() {
+    return helper.padInner$('div:eq(' + targetLineNumber + ')');
+  }
+
+  var getDistanceBetweenTargetLineAndSuggestions = function() {
+    var $suggestionsPopup = helper.padOuter$('div#autocomp');
+
+    // create a temp element to get its position, then remove it
+    var $endOfTargetLine = $('<span>x</span>');
+    getTargetLine().append($endOfTargetLine);
+
+    var top  = $suggestionsPopup.position().top  - $endOfTargetLine.position().top;
+    var left = $suggestionsPopup.position().left - $endOfTargetLine.position().left;
+
+    $endOfTargetLine.remove();
+
+    return { top: top, left: left };
+  }
+
+  before(function(done) {
+    utils = ep_autocomp_test_helper.utils;
+    var test = this;
+
+    helper.newPad(function() {
+      utils.clearPad(function() {
+        utils.resetFlagsAndEnableAutocomplete(function() {
+          utils.writeWordsWithC(function() {
+            // get baseline for tests
+            var $targetLine = helper.padInner$('div').last();
+            targetLineNumber = $targetLine.index();
+
+            $targetLine.sendkeys('{selectall}');
+            $targetLine.sendkeys('c');
+
+            utils.waitShowSuggestions(test, function() {
+              baseline = getDistanceBetweenTargetLineAndSuggestions();
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    this.timeout(60000);
+  });
+
+  context('when text is too long to fit on a single line', function() {
+    before(function(done) {
+      var test = this;
+
+      var $targetLine = getTargetLine();
+      $targetLine.sendkeys('{selectall}');
+      $targetLine.sendkeys(' a'.repeat(250));
+
+      utils.waitHideSuggestions(test, function() {
+        // target line might be long enough now, we can type 'c' to show suggestions
+        // further down the screen
+        var $targetLine = getTargetLine();
+        $targetLine.sendkeys(' c');
+
+        utils.waitShowSuggestions(test, done);
+      });
+    });
+
+    it('displays suggestions with the same distance to the caret position', function(done) {
+      var distance = getDistanceBetweenTargetLineAndSuggestions();
+      expect(distance.left).to.be(baseline.left);
+      expect(distance.top).to.be(baseline.top);
+      done();
+    });
+
+    // could be any text formatting, bold is just an example
+    context('and part of the text before caret is bold', function() {
+      before(function(done) {
+        var $targetLine = getTargetLine();
+        helper.selectLines($targetLine, $targetLine, 100, 200);
+        var $boldButton = helper.padChrome$('.buttonicon-bold');
+        $boldButton.click();
+
+        // force suggestions to be shown again
+        var $targetLine = getTargetLine();
+        $targetLine.sendkeys('{selectall}{rightarrow}');
+        $targetLine.sendkeys(' c');
+        utils.waitShowSuggestions(this, done);
+      });
+
+      it('displays suggestions with the same distance to the caret position', function(done) {
+        var distance = getDistanceBetweenTargetLineAndSuggestions();
+        expect(distance.left).to.be(baseline.left);
+        expect(distance.top).to.be(baseline.top);
+        done();
+      });
+    });
+  });
+});

--- a/static/tests/frontend/specs/utils.js
+++ b/static/tests/frontend/specs/utils.js
@@ -146,6 +146,14 @@ ep_autocomp_test_helper.utils = {
       return outer$('div#autocomp').is(":visible");
     }, 3000).done(cb);
   },
+  waitHideSuggestions: function(test, cb){
+    test.timeout(5000);
+    helper.waitFor(function(){
+      var outer$ = helper.padOuter$;
+      return !outer$('div#autocomp').is(":visible");
+    }, 3000).done(cb);
+  },
+
   disableCaseSensitiveMatch: function(){
     var autocompConfig = helper.padChrome$.window.clientVars.ep_autocomp;
     autocompConfig.caseSensitiveMatch = false;


### PR DESCRIPTION
In order to get the exact position of the caret on pad_inner, we need to clone the entire `div` (and copy its styles for all inner tags). If we don't do that, the suggestions would be placed on the wrong position for some scenarios:

- when `div` has multiple lines of text, the suggestions would be placed on the right of the pad_inner;
- when `div` has a child node before the `span` where caret is (for example, if there's some text in bold before caret position), the suggestions would be placed on the right of the caret;

## Before
![autocomp-1](https://user-images.githubusercontent.com/836386/41930069-5d6f5f2a-7950-11e8-8f20-9c3fb56cb90a.JPG)
![autocomp-2](https://user-images.githubusercontent.com/836386/41930070-5d9179b6-7950-11e8-9a54-6c1be6e9a665.JPG)
![autocomp-3](https://user-images.githubusercontent.com/836386/41930072-5db3108a-7950-11e8-9ab8-c8e81219379d.JPG)

## After
![fix_autocomp](https://user-images.githubusercontent.com/836386/41930123-836b22a4-7950-11e8-9281-601fc6903697.gif)
