### PR TITLE
Allow other plugins to force to show suggestions identical to typed text

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -354,7 +354,7 @@ var autocomp = {
     if(!$('#options-autocomp').is(':checked')) return;
     autocomp.update(context);
   },
-  update:function(context, fixedSuggestions, customRegex, customRegexIndex){
+  update:function(context, fixedSuggestions, customRegex, customRegexIndex, showExactMatch){
     if(context.rep.selStart === null) return;
     //as edit event is called when anyone edits, we must ensure it is the current user
     if(!autocomp.isEditByMe(context)) return;
@@ -370,7 +370,7 @@ var autocomp = {
     }
 
     suggestions = fixedSuggestions || autocomp.getPossibleSuggestions(context);
-    filteredSuggestions = autocomp.filterSuggestionList(partialWord, suggestions);
+    filteredSuggestions = autocomp.filterSuggestionList(partialWord, suggestions, showExactMatch);
 
     if(filteredSuggestions.length===0){
       this.closeSuggestionBox();
@@ -386,11 +386,13 @@ var autocomp = {
     var caretPosition = autocomp.caretPosition(context);
     autocomp.createAutocompHTML(filteredSuggestions, caretPosition, partialWord, context);
   },
-  filterSuggestionList:function(partialWord,possibleSuggestions){
+  filterSuggestionList:function(partialWord, possibleSuggestions, showExactMatch){
     /*
     gets:
     - the string for which we want matches ("partialWord")
     - a list of all completions
+    - a flag indicating if should discard an exact match or not ("showExactMatch"),
+      like showing a suggestion "abc" when partialWord is also "abc"
 
     returns: an array with objects containing suggestions as object with
     {
@@ -409,8 +411,8 @@ var autocomp = {
       var allowEmptyPartialWord   = (partialWord.length === 0 && autocomp.showOnEmptyWords);
       // does partialWord start at the beginning of possibleSuggestion?
       var isSubtextOfSuggestion   = autocomp.subtextOfSuggestion(possibleSuggestion, partialWord);
-      // avoid autocomplete "abc" with "abc"
-      var notSameWordOfSuggestion = (possibleSuggestion !== partialWord);
+      // avoid autocomplete "abc" with "abc", unless explicitly configured to do that
+      var notSameWordOfSuggestion = showExactMatch || (possibleSuggestion !== partialWord);
 
       if((allowEmptyPartialWord || isSubtextOfSuggestion) && notSameWordOfSuggestion){
         var complementaryString = possibleSuggestion.slice(partialWord.length);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -163,7 +163,7 @@ var autocomp = {
     //SPACE AND CONTROL PRESSED
     if(this.ctrlSpacePressed(context.evt) && autocomp.enableShowSuggestionWithCtrlAndSpace){
       if($autocomp.is(":hidden")){
-        this.update(context);
+        this.updateSuggestions(context);
       }else{
         this.closeSuggestionBox();
       }
@@ -352,15 +352,79 @@ var autocomp = {
     if (!autocomp.processEditEvent) return;
     //if disabled in settings
     if(!$('#options-autocomp').is(':checked')) return;
-    autocomp.update(context);
+    autocomp.updateSuggestions(context);
   },
-  update:function(context, fixedSuggestions, customRegex, customRegexIndex, showExactMatch){
+
+  // WARNING: this method is now deprecated, and should not be used anymore.
+  // Please use `updateSuggestions` instead.
+  update:function(context, fixedSuggestions, customRegex, customRegexIndex){
+    console.warn("autocomp.update() is deprecated, please use autocomp.updateSuggestions() instead");
+
+    this.updateSuggestions(context, {
+      fixedSuggestions: fixedSuggestions,
+      customRegex: customRegex,
+      customRegexIndex: customRegexIndex,
+    });
+  },
+
+  /*
+  Force suggestions to be updated.
+  Parameters:
+    - context: the context usually provided by Etherpad on plugin hooks
+    - configs: an object with customizations for this update:
+      - fixedSuggestions: an array of suggestions to be provided to the user, if you
+        don't want autocomp to scan through the entire pad text to build the list of
+        suggestions. Useful when you want to provide different lists of suggestions
+        according to the line attributes, for example.
+
+      - customRegex: regex to be used to select which text before caret should matches
+        the available suggestions (provided by fixedSuggestions or built by autocomp).
+        Useful when you want to consider a broader context for the suggestions.
+        Default: all chars since last white-space (`/[\S]*$/`).
+
+      - customRegexIndex: index on the match of customRegex. Must be one of the
+        available indexes of the result of `textBeforeCaret.match(customRegex)`.
+        Default: 0 (entire regex match);
+
+      - showExactMatch: flag to allow suggestions matching the exact text to be shown.
+        Default: false;
+
+  Example:
+  You have a strict list of sections your pad must have ("Introduction",
+  "Main Content", "Conclusion", "References", "References - Images"), and you need
+  this suggestions to be displayed only when line has a `<h1>`.
+
+  A section begins with the number and is followed by ".", like this: "1. Introduction".
+
+  So you call updateSuggestions whenever the user types something on a line with
+   `<h1>`, and provide the following configs:
+  ```
+  var configs = {
+    fixedSuggestions: ["Introduction", "Main Content", "Conclusion", "References", "References - Images"],
+    customRegex: / ^\d\. (.*)$/, // ignore section number on the beginning of the line
+    customRegexIndex: 1, // capture what is inside the `(.*)` of customRegex
+    showExactMatch: true, // allow a line with "4. References" to still show the options
+                          // "References" *and* "References - Images"
+  };
+  ```
+  */
+  updateSuggestions:function(context, configs){
     if(context.rep.selStart === null) return;
     //as edit event is called when anyone edits, we must ensure it is the current user
     if(!autocomp.isEditByMe(context)) return;
 
+    //define defaults for configs
+    configs = configs || {};
+    //TODO: make custom regex dependent on the clientVars.ep_autocomp.regexToFind.
+    //what is the section to be considered? Usually, this will be everything which is not a space.
+    //The Regex includes the $ (end of line) so we can find the section of interest beginning from the strings end.
+    //(To understand better, just paste into regexpal.com)
+    configs.customRegex = configs.customRegex || /[\S]*$/;
+    configs.customRegexIndex = configs.customRegexIndex || 0;
+    configs.showExactMatch = configs.showExactMatch || false;
+
     //get the word which is being typed
-    var partialWord = this.getCurrentPartialWord(context, customRegex, customRegexIndex);
+    var partialWord = this.getCurrentPartialWord(context, configs.customRegex, configs.customRegexIndex);
 
     //hide suggestions if no word is typed
     var wordIsEmpty = partialWord.length === 0;
@@ -369,8 +433,8 @@ var autocomp = {
       return;
     }
 
-    suggestions = fixedSuggestions || autocomp.getPossibleSuggestions(context);
-    filteredSuggestions = autocomp.filterSuggestionList(partialWord, suggestions, showExactMatch);
+    suggestions = configs.fixedSuggestions || autocomp.getPossibleSuggestions(context);
+    filteredSuggestions = autocomp.filterSuggestionList(partialWord, suggestions, configs.showExactMatch);
 
     if(filteredSuggestions.length===0){
       this.closeSuggestionBox();
@@ -731,14 +795,7 @@ var autocomp = {
       hardcodedSuggestions.concat(dynamicSuggestions).concat(sourceSuggestions).sort(), //combine dynamic and static array, the resulting array is than sorted
     true);//true, since input array is already sorted
   },
-  getCurrentPartialWord:function(context, customRegex, customRegexIndex){
-    //TODO: make section marker dependend on the clientVars.ep_autocomp.regexToFind.
-    //what is the  section to be considered? Usually, this will be everything which is not a space.
-    //The Regex includes the $ (end of line) so we can find the section of interest beginning form the strings end.
-    //(To understand better, just paste into regexpal.com)
-    var sectionMarker = customRegex || /[\S]*$/;
-    var index = customRegexIndex || 0;
-
+  getCurrentPartialWord:function(context, sectionMarker, index){
     var caretColumnPosition = this.getCaretColumnOnline(context);
     var currentLine         = this.getCurrentLine(context);
     var textBeforeCaret     = currentLine.slice(0,caretColumnPosition); //from beginning until caret

--- a/static/tests/frontend/specs/autoComplete.js
+++ b/static/tests/frontend/specs/autoComplete.js
@@ -1,26 +1,25 @@
 describe("ep_autocomp - show autocomplete suggestions", function(){
   var utils;
 
-  before(function () {
+  // use a single pad for all the tests (so they run faster)
+  before(function(cb) {
     utils = ep_autocomp_test_helper.utils;
-  });
-
-  beforeEach(function(cb){
-    helper.newPad(function(){
-      utils.clearPad(function() {
-        utils.resetFlagsAndEnableAutocomplete(function(){
-          utils.writeWordsWithC(cb);
-        });
-      });
-    });
+    helper.newPad(cb);
     this.timeout(60000);
   });
 
+  beforeEach(function(cb){
+    utils.clearPad(function() {
+      utils.resetFlagsAndEnableAutocomplete(function(){
+        utils.writeWordsWithC(cb);
+      });
+    });
+  });
 
   it("displays suggestions when user types a word that matches others from the text", function(done){
     var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
-    var $lastLine =  inner$("div").last();
+    var $lastLine = inner$("div").last();
     $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     utils.waitShowSuggestions(this, function(){
@@ -30,29 +29,43 @@ describe("ep_autocomp - show autocomplete suggestions", function(){
     });
   });
 
+  it("does not display suggestions that are identical to the typed word", function(done){
+    var inner$ = helper.padInner$;
+    var test = this;
+
+    var $lastLine = inner$("div").last();
+    $lastLine.sendkeys('{selectall}');
+    $lastLine.sendkeys('chrom');
+    utils.waitShowSuggestions(test, function(){
+      // then check if suggestions are hidden if the word is identical
+      var $lastLine = inner$("div").last();
+      $lastLine.sendkeys('e');
+      utils.waitHideSuggestions(test, done);
+    });
+  });
+
   it("hides suggestions when user types a word that does not match any other from the text", function(done){
     var inner$ = helper.padInner$;
     var test = this;
 
     // first make sure suggestions are displayed
-    var $lastLine =  inner$("div").last();
+    var $lastLine = inner$("div").last();
     $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     utils.waitShowSuggestions(test, function(){
       // then check if suggestions are hidden if there are no words that match
-      var $lastLine =  inner$("div").last();
+      var $lastLine = inner$("div").last();
       $lastLine.sendkeys('notSavedWord');
       utils.waitHideSuggestions(test, done);
     });
   });
 
   it("hides suggestions when user types ESC", function(done){
-    var outer$ = helper.padOuter$;
     var inner$ = helper.padInner$;
     var test = this;
 
     // first make sure suggestions are displayed
-    var $lastLine =  inner$("div").last();
+    var $lastLine = inner$("div").last();
     $lastLine.sendkeys('{selectall}');
     $lastLine.sendkeys('c');
     utils.waitShowSuggestions(test, function(){


### PR DESCRIPTION
Create flag on method to filter available suggestions that force suggestions identical to the partial text to be displayed. It is not used by default by this plugin, but might be used by other plugins that control the `autocomp` object.

Example of usage
=========

On our usage of `ep_autocomp`, we suggest the full line instead of each word. So we might have something like this:

![image](https://user-images.githubusercontent.com/836386/51494909-94820580-1da1-11e9-8a42-575d86659f22.png)

If user types `PETER` and presses ENTER, we would have the selection of `PETER PAN`, but the idea was to simply select `PETER` and go to the next line.