### PR TITLE
[refactor] Extract aceEditorCSS hook into a separated file

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,7 +11,7 @@
         "aceEditEvent"          : "ep_autocomp/static/js/index",
         "aceKeyEvent"           : "ep_autocomp/static/js/index",
         "postAceInit"           : "ep_autocomp/static/js/index",
-      	"aceEditorCSS"	        : "ep_autocomp/static/js/index"
+        "aceEditorCSS"	        : "ep_autocomp/static/js/aceEditorCSS"
       }
     }
   ]

--- a/static/js/aceEditorCSS.js
+++ b/static/js/aceEditorCSS.js
@@ -1,0 +1,3 @@
+exports.aceEditorCSS = function(hook_name, cb){
+  return ["/ep_autocomp/static/css/autocomp.css"];
+} // inner pad CSS

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -842,11 +842,6 @@ exports.aceEditEvent = function(type, context, cb) {
   autocomp.aceEditEvent(type, context, cb);
 };
 
-exports.aceEditorCSS = function(hook_name, cb){
-  return ["/ep_autocomp/static/css/autocomp.css"];
-} // inner pad CSS
-
-
 exports.aceKeyEvent = function (type, context, cb) {
   return autocomp.aceKeyEvent(type, context);
 };


### PR DESCRIPTION
Allow hook to be executed on server-side, so this plugin can have its CSS files bundled & minimised by ep_webpack.

See [this PR](https://github.com/storytouch/ep_webpack/pull/3) for more info.